### PR TITLE
Refine IFTM navbar shortcut styling

### DIFF
--- a/src/assets/iftm-logo.svg
+++ b/src/assets/iftm-logo.svg
@@ -1,0 +1,12 @@
+<svg width="250" height="250" viewBox="0 0 250 250" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">Logotipo do IFTM</title>
+  <circle cx="35" cy="35" r="35" fill="#C11F27" />
+  <rect x="90" width="70" height="70" rx="12" fill="#2EA84A" />
+  <rect x="180" width="70" height="70" rx="12" fill="#2EA84A" />
+  <rect y="90" width="70" height="70" rx="12" fill="#2EA84A" />
+  <rect x="90" y="90" width="70" height="70" rx="12" fill="#2EA84A" />
+  <rect x="180" y="90" width="70" height="70" rx="12" fill="#2EA84A" />
+  <rect y="180" width="70" height="70" rx="12" fill="#2EA84A" />
+  <rect x="90" y="180" width="70" height="70" rx="12" fill="#2EA84A" />
+  <rect x="180" y="180" width="70" height="70" rx="12" fill="#2EA84A" />
+</svg>

--- a/src/components/Navbar/index.js
+++ b/src/components/Navbar/index.js
@@ -17,6 +17,7 @@ import {Link} from 'react-router-dom';
 import { toast } from 'react-toastify';
 import api from '../../services/api.js';
 import { LimpaFiltrosLocalSession } from '../../services/functions.js';
+import iftmLogo from '../../assets/iftm-logo.svg';
 
 const pages = ['📚 Provas', '🧾 Simulados', '📒Avaliações', '📔Questões', '🎓 Sisu', '➕Pratique Tabuada'];
 if(localStorage.getItem(Config.ADMIN) === '1'){
@@ -310,6 +311,12 @@ const ResponsiveAppBar = () => {
                 display: { xs: 'block', md: 'none' },
               }}
             >
+              <MenuItem onClick={(e) => selecionaFiltroProva('IFTM')}>
+                <div className='iftm-option'>
+                  <img src={iftmLogo} alt='IFTM' className='iftm-logo' />
+                  <span className='iftm-label'>IFTM</span>
+                </div>
+              </MenuItem>
               {pages.map((page, index) => (
                 index != 0 && index != 4 && index != 6 ?
                 <MenuItem key={index} onClick={(e) => SelecionaOpcao(page)}>
@@ -451,6 +458,17 @@ const ResponsiveAppBar = () => {
             <a href='/'>ConQuest</a>
           </Typography>
           <Box sx={{ flexGrow: 1, display: { xs: 'none', md: 'flex' } }}>
+            <Button
+              aria-label='Provas IFTM'
+              onClick={(e) => selecionaFiltroProva('IFTM')}
+              className='iftm-nav-button'
+              sx={{ my: 1, display: { xs: 'none', md: 'flex' }, minWidth: 'auto', color: 'white' }}
+            >
+              <span className='iftm-option'>
+                <img src={iftmLogo} alt='IFTM' className='iftm-logo' />
+                <span className='iftm-label'>IFTM</span>
+              </span>
+            </Button>
             {pages.map((page, index) => (
               index != 0 && index != 4 && index != 6 ?
               <Button

--- a/src/components/Navbar/style.css
+++ b/src/components/Navbar/style.css
@@ -1,0 +1,34 @@
+.iftm-nav-button {
+  margin-right: 12px;
+  padding: 6px 12px;
+  display: inline-flex;
+  align-items: center;
+  color: inherit;
+}
+
+.iftm-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.iftm-logo {
+  width: 28px;
+  height: auto;
+  display: block;
+}
+
+.iftm-label {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+@media (max-width: 900px) {
+  .iftm-nav-button {
+    padding: 0;
+  }
+
+  .iftm-logo {
+    width: 24px;
+  }
+}


### PR DESCRIPTION
## Summary
- update the mobile IFTM menu entry to show the logo paired with an IFTM label like the avaliações listing
- restyle the desktop navbar shortcut so the logo and label sit side by side with reduced icon sizing

## Testing
- npm start


------
https://chatgpt.com/codex/tasks/task_e_68de79a4dcfc832c9f42f102634f01a5