### PR TITLE
Update static web app workflow to run only on main pushes

### DIFF
--- a/.github/workflows/azure-static-web-apps-calm-coast-0b8531c10.yml
+++ b/.github/workflows/azure-static-web-apps-calm-coast-0b8531c10.yml
@@ -4,14 +4,9 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, synchronize, reopened, closed]
-    branches:
-      - main
 
 jobs:
   build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     env:
@@ -34,16 +29,3 @@ jobs:
           output_location: "build" # Built app content directory - optional
           ###### End of Repository/Build Configurations ######
 
-  close_pull_request_job:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    name: Close Pull Request Job
-    env:
-      CI: false
-    steps:
-      - name: Close Pull Request
-        id: closepullrequest
-        uses: Azure/static-web-apps-deploy@v1
-        with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_CALM_COAST_0B8531C10 }}
-          action: "close"


### PR DESCRIPTION
## Summary
- remove pull request triggers from the Azure Static Web Apps workflow
- simplify the workflow jobs so it only runs the deployment on pushes to main

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de7daf3774832c9b64abe2b81739b4